### PR TITLE
speedtest only default interface

### DIFF
--- a/kintyre_speedtest.py
+++ b/kintyre_speedtest.py
@@ -244,6 +244,25 @@ def main(output=output_to_hec):
         output(json.dumps(results))
         return
 
+    if interface is None:
+        # If ifcfg.default_interface() is broken (as it is for MacOS),
+        # fall back to using all interfaces reported by ifcfg.interfaces()
+        # with some obvious exclusions
+        interfaces = ifcfg.interfaces()
+        for name, interface in list(interfaces.items()):
+            # Skip loopback adapter
+            if name.startswith("lo"):
+                continue
+            if interface.get("status", None) == "inactive":
+                continue
+            if interface["inet"] is None:
+                continue
+            d = {}
+            for k in ("device", "ether", "status", "mtu", "txbytes", "rxbytes"):
+                if k in interface:
+                    d[k] = interface[k]
+            if_for_testing[(interface['inet'], interface['device'])] = d
+
     d = {}
     # Todo:  See if there are any other interesting goodies provided by Windows
     # Todo:  Capture the "Description" field from ipconfig; extend Windows class in ifcfg

--- a/kintyre_speedtest.py
+++ b/kintyre_speedtest.py
@@ -234,7 +234,7 @@ def add_platform_info(d):
 def main(output=output_to_hec):
     if_for_testing = {}
     try:
-        interfaces = ifcfg.interfaces()
+        interface = ifcfg.default_interface()
     except Exception as e:
         sys.stderr.write("Unable to get interface info.  Falling back to simple output. "
                          "Error: {0}\n".format(e))
@@ -244,23 +244,15 @@ def main(output=output_to_hec):
         output(json.dumps(results))
         return
 
-    for name, interface in list(interfaces.items()):
-        # Skip loopback adapter
-        if name.startswith("lo"):
-            continue
-        if interface.get("status", None) == "inactive":
-            continue
-        if interface["inet"] is None:
-            continue
-        d = {}
-        # Todo:  See if there are any other interesting goodies provided by Windows
-        # Todo:  Capture the "Description" field from ipconfig; extend Windows class in ifcfg
-        for k in ("device", "ether", "status", "mtu", "txbytes", "rxbytes"):
-            if k in interface:
-                d[k] = interface[k]
-        if_for_testing[(interface['inet'], interface['device'])] = d
+    d = {}
+    # Todo:  See if there are any other interesting goodies provided by Windows
+    # Todo:  Capture the "Description" field from ipconfig; extend Windows class in ifcfg
+    for k in ("device", "ether", "status", "mtu", "txbytes", "rxbytes"):
+        if k in interface:
+            d[k] = interface[k]
+    if_for_testing[(interface['inet'], interface['device'])] = d
 
-    sys.stderr.write("DEBUG:  iterfaces for testing: {0!r}\n".format(if_for_testing))
+    sys.stderr.write("DEBUG:  interface for testing: {0!r}\n".format(if_for_testing))
 
     net_info = get_macosx_network_hw()
     sys.stderr.write("DEBUG:  get_macosx_hardware() returns: {0!r}\n".format(net_info))


### PR DESCRIPTION
Run speedtest on ifcfg.default_route() instead of on all interfaces reported by ifcfg.interfaces()